### PR TITLE
Skip geoportail tests

### DIFF
--- a/.github/workflows/cicd_light.yml
+++ b/.github/workflows/cicd_light.yml
@@ -30,5 +30,5 @@ jobs:
 
       - name: Run tests with pytest
         shell: micromamba-shell {0}
-        run: python -m pytest ./test -s --log-cli-level DEBUG
+        run: python -m pytest ./test -s --log-cli-level DEBUG -m "not geoportail"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # dev
+tests: 
+- add geoportail marker to skip tests relying on geoportail (they are now played on PR to the master branch only)
+- bugfix on standardization test file path
 
 # 1.1.0
 standardization: handle malformed laz input ("Global encoding WKT flag not set for point format 6 - 10")

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,9 @@ install:
 	pip install -e .
 
 testing:
+	python -m pytest ./test -s --log-cli-level DEBUG -m "not geoportail"
+
+testing_full:
 	python -m pytest ./test -s --log-cli-level DEBUG
 
 clean:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,13 @@ readme = "README.md"
 authors = [
     { name = "Guillaume Liegard", email = "guillaume.liegard@ign.fr" }
 ]
+
 [tool.setuptools.dynamic]
 version = {attr = "pdaltools._version.__version__"}
 [tool.setuptools]
 packages = [ "pdaltools" ]
+
+[tool.pytest.ini_options]
+markers = [
+    "geoportail: marks tests that request the (sometimes unreliable) geoportail.gouv.fr",
+]

--- a/test/test_color.py
+++ b/test/test_color.py
@@ -58,7 +58,6 @@ def test_download_image_raise2():
         retry_download("9001", layer, minx, miny, maxx, maxy, pixel_per_meter, OUTPUT_FILE, 15)
 
 
-@pytest.mark.geoportail
 def test_retry_on_server_error():
     with requests_mock.Mocker() as mock:
         mock.get(requests_mock.ANY, status_code=502, reason="Bad Gateway")
@@ -69,7 +68,6 @@ def test_retry_on_server_error():
         assert len(history) == 3
 
 
-@pytest.mark.geoportail
 def test_retry_on_connection_error():
       with requests_mock.Mocker() as mock:
         mock.get(requests_mock.ANY, exc=requests.exceptions.ConnectionError)
@@ -81,7 +79,6 @@ def test_retry_on_connection_error():
         assert len(history) == 3
 
 
-@pytest.mark.geoportail
 def test_retry_param():
 
     # Here you can change retry params

--- a/test/test_color.py
+++ b/test/test_color.py
@@ -24,6 +24,7 @@ INPUT_PATH = os.path.join(TEST_PATH, 'data/test_noepsg_043500_629205_IGN69.laz')
 OUTPUT_FILE = TMPDIR + "Semis_2021_0435_6292_LA93_IGN69.las"
 
 
+@pytest.mark.geoportail
 def test_epsg_fail():
     with pytest.raises(requests.exceptions.HTTPError, match="400 Client Error: BadRequest for url") :
         color.color(INPUT_PATH, OUTPUT_FILE, "", 0.1, 15)
@@ -38,22 +39,26 @@ maxy=6292000
 pixel_per_meter=0.1
 
 
+@pytest.mark.geoportail
 def test_download_image_ok():
     color.download_image_from_geoportail(epsg, layer, minx, miny, maxx, maxy, pixel_per_meter, OUTPUT_FILE, 15)
 
 
+@pytest.mark.geoportail
 def test_download_image_raise1():
     retry_download = color.retry(2, 5)(color.download_image_from_geoportail)
     with pytest.raises(requests.exceptions.HTTPError):
         retry_download(epsg, "MAUVAISE_COUCHE", minx, miny, maxx, maxy, pixel_per_meter, OUTPUT_FILE, 15)
 
 
+@pytest.mark.geoportail
 def test_download_image_raise2():
     retry_download = color.retry(2, 5)(color.download_image_from_geoportail)
     with pytest.raises(requests.exceptions.HTTPError):
         retry_download("9001", layer, minx, miny, maxx, maxy, pixel_per_meter, OUTPUT_FILE, 15)
 
 
+@pytest.mark.geoportail
 def test_retry_on_server_error():
     with requests_mock.Mocker() as mock:
         mock.get(requests_mock.ANY, status_code=502, reason="Bad Gateway")
@@ -64,6 +69,7 @@ def test_retry_on_server_error():
         assert len(history) == 3
 
 
+@pytest.mark.geoportail
 def test_retry_on_connection_error():
       with requests_mock.Mocker() as mock:
         mock.get(requests_mock.ANY, exc=requests.exceptions.ConnectionError)
@@ -75,6 +81,7 @@ def test_retry_on_connection_error():
         assert len(history) == 3
 
 
+@pytest.mark.geoportail
 def test_retry_param():
 
     # Here you can change retry params
@@ -84,5 +91,3 @@ def test_retry_param():
 
     with pytest.raises(requests.exceptions.HTTPError):
         raise_server_error()
-
-

--- a/test/test_standardize_format.py
+++ b/test/test_standardize_format.py
@@ -100,8 +100,8 @@ def test_standardize_does_NOT_produce_any_warning_with_Lasinfo():
     # bad file on the store (44 Mo)
     # input_file = "/var/data/store-lidarhd/developpement/standaLAS/demo_standardization/Semis_2022_0584_6880_LA93_IGN69.laz"
 
-    input_file = "./test/data/classified_laz/test_data_77050_627755_LA93_IGN69.laz"
-    output_file = "./tmp/test_standardize_produce_no_warning_with_lasinfo.las"
+    input_file = os.path.join(test_path, "data/classified_laz/test_data_77050_627755_LA93_IGN69.laz")
+    output_file = os.path.join(tmp_path, "test_standardize_produce_no_warning_with_lasinfo.las")
 
     # if you want to see input_file warnings
     # assert_lasinfo_no_warning(input_file)

--- a/test/test_unlock.py
+++ b/test/test_unlock.py
@@ -1,10 +1,10 @@
 import laspy
 import os
 import shutil
-import pdal
+import pytest
 
 from pdaltools.color import color, pdal_info_json
-from pdaltools.unlock_file import unlock_file
+from pdaltools.unlock_file import unlock_file, copy_and_hack_decorator
 
 
 TEST_PATH = os.path.dirname(os.path.abspath(__file__))
@@ -20,7 +20,19 @@ def setup_module(module):
     os.mkdir(TMPDIR)
 
 
-def test_copy_and_hack_decorator():
+@copy_and_hack_decorator
+def decorated_pdal_info_json(input_file: str):
+    return pdal_info_json(input_file)
+
+
+def test_copy_and_hack_decorator_simple():
+    TMP_FILE = os.path.join(TMPDIR, "copy_and_hack_simple.laz")
+    shutil.copy(LAZ_FILE, TMP_FILE)
+    decorated_pdal_info_json(TMP_FILE)
+
+
+@pytest.mark.geoportail
+def test_copy_and_hack_decorator_color():
     # bug during laz opening in pdal (solved with copy_and_hack_decorator)
     LAS_FILE = os.path.join(TMPDIR, "test_pdalfail_0643_6319_LA93_IGN69.las")
 


### PR DESCRIPTION
add marker to tests that rely on geoportail
On pull requests to `dev`: `geoportail` marked tests are skipped
On pull requests to `master`: all tests are played 
