### PR TITLE
PATCH: Always remove tmp orthoimages in color.color

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # dev
 
+# 1.3.1
+- fix color: ensure that tmp orthoimages are deleted after use by using the namedTemporaryFile properly.
+
 # 1.3.0
 - color: support colorization for <0.2m clouds (including height=0/width=0)
 - color: ceil width/height to have a bbox that contains all points

--- a/pdaltools/_version.py
+++ b/pdaltools/_version.py
@@ -1,4 +1,4 @@
-__version__ = "1.3.0"
+__version__ = "1.3.1"
 
 
 if __name__ == "__main__":

--- a/pdaltools/color.py
+++ b/pdaltools/color.py
@@ -151,15 +151,17 @@ def color(
 
     tmp_ortho = None
     if color_rvb_enabled:
-        tmp_ortho = tempfile.NamedTemporaryFile().name
+        tmp_ortho = tempfile.NamedTemporaryFile()
         download_image_from_geoportail_retrying(
-            proj, "ORTHOIMAGERY.ORTHOPHOTOS", minx, miny, maxx, maxy, pixel_per_meter, tmp_ortho, timeout_second
+            proj, "ORTHOIMAGERY.ORTHOPHOTOS", minx, miny, maxx, maxy, pixel_per_meter, tmp_ortho.name, timeout_second
         )
-        pipeline |= pdal.Filter.colorization(raster=tmp_ortho, dimensions="Red:1:256.0, Green:2:256.0, Blue:3:256.0")
+        pipeline |= pdal.Filter.colorization(
+            raster=tmp_ortho.name, dimensions="Red:1:256.0, Green:2:256.0, Blue:3:256.0"
+        )
 
     tmp_ortho_irc = None
     if color_ir_enabled:
-        tmp_ortho_irc = tempfile.NamedTemporaryFile().name
+        tmp_ortho_irc = tempfile.NamedTemporaryFile()
         download_image_from_geoportail_retrying(
             proj,
             "ORTHOIMAGERY.ORTHOPHOTOS.IRC",
@@ -168,10 +170,10 @@ def color(
             maxx,
             maxy,
             pixel_per_meter,
-            tmp_ortho_irc,
+            tmp_ortho_irc.name,
             timeout_second,
         )
-        pipeline |= pdal.Filter.colorization(raster=tmp_ortho_irc, dimensions="Infrared:1:256.0")
+        pipeline |= pdal.Filter.colorization(raster=tmp_ortho_irc.name, dimensions="Infrared:1:256.0")
 
     pipeline |= pdal.Writer.las(
         filename=output_file, extra_dims=writer_extra_dims, minor_version="4", dataformat_id="8"


### PR DESCRIPTION
The NamedTemporaryFile was created and direcly forgotten since only its name was assigned to a variable.

As a result, the resulting file was never properly deleted after coloration. This would clog memory of always-running servers (no reboot = no regular deletion of the /tmp/ folder). 

By assigning the file and not its name to a variable, the deletion or conservation of the file can be control by removing or keeping the variable in the python context.