### PR TITLE
color: Replace pdal info subprocess with python-pdal quickinfo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# dev
+- replace `pdal info --metadata` subprocess by a python command (used in the `color` module in particular)
+
 # 1.4.1
 - fix copy_and_hack_decorator (was not returning the decorated function output)
 

--- a/test/test_color.py
+++ b/test/test_color.py
@@ -31,7 +31,10 @@ OUTPUT_FILE_SINGLE_POINT_CLOUD = TMPDIR + "test_data_0436_6384_LA93_IGN69_single
 
 @pytest.mark.geoportail
 def test_epsg_fail():
-    with pytest.raises(requests.exceptions.HTTPError, match="400 Client Error: BadRequest for url"):
+    with pytest.raises(
+        RuntimeError,
+        match="EPSG could not be inferred from metadata: No 'srs' key in metadata.",
+    ):
         color.color(INPUT_PATH, OUTPUT_FILE, "", 0.1, 15)
 
 


### PR DESCRIPTION
Remplacement du subprocess `pdal info --metadata` dans les methodes de colorisation de las/laz

Devrait résoudre:
- https://github.com/IGNF/ign-pdal-tools/issues/25
