### PR TITLE
Fix classes removal in standardisation

### DIFF
--- a/.github/workflows/cicd_light.yml
+++ b/.github/workflows/cicd_light.yml
@@ -8,8 +8,11 @@ on:
 
 
 jobs:
-  docker_build_and_test:
-    runs-on: ubuntu-latest
+  test_light:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
     permissions:
         contents: read
         packages: write

--- a/pdaltools/count_occurences/count_occurences_for_attribute.py
+++ b/pdaltools/count_occurences/count_occurences_for_attribute.py
@@ -34,7 +34,7 @@ def compute_count_one_file(filepath: str, attribute: str = "Classification") -> 
     pipeline |= pdal.Filter.stats(dimensions=attribute, count=attribute)
     pipeline.execute()
     # List of "class/count" on the only dimension that is counted
-    raw_counts = pipeline.metadata["metadata"]["filters.stats"]["statistic"][0]["counts"]
+    raw_counts = pipeline.metadata["metadata"]["filters.stats"]["statistic"][0].get("counts", [])
     split_counts = [c.split("/") for c in raw_counts]
     try:
         # Try to prettify the value by converting it to an integer (eg. for Classification that


### PR DESCRIPTION
- add automatic tests on macos (to prevent incompatibility issues)
- use pdal.Filter.expression to remove points in `standardize`