### PR TITLE
Bump version to 1.7.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# dev
+# 1.7.8
 - Update dependency versions
 - make count_occurences usable as a package
 - add_points_to_pointcloud does not raise an error when there is no point in the tile

--- a/pdaltools/_version.py
+++ b/pdaltools/_version.py
@@ -1,4 +1,4 @@
-__version__ = "1.7.7"
+__version__ = "1.7.8"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- Update dependency versions
- make count_occurences usable as a package
- add_points_to_pointcloud does not raise an error when there is no point in the tile