### PR TITLE
Bump version to 1.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 
+# 1.8.0
 - remove add_points_in_las.py (replaced by add_points_in_pointcloud.py)
 - colorization :
   - orthophotos can be downloaded by blocks and merged, in order for requests to match the maximum download size of the geoplateforme.

--- a/pdaltools/_version.py
+++ b/pdaltools/_version.py
@@ -1,4 +1,4 @@
-__version__ = "1.7.11"
+__version__ = "1.8.0"
 
 if __name__ == "__main__":
     print(__version__)


### PR DESCRIPTION
Changes:
- remove add_points_in_las.py (replaced by add_points_in_pointcloud.py)
- colorization :
  - orthophotos can be downloaded by blocks and merged, in order for requests to match the maximum download size of the geoplateforme.
  - force image min/max to match full pixel values