### PR TITLE
Bump version to 1.12.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+# 1.12.3
 - [fix] add_points_in_pointcloud: format consistency when input shapefile does not have a crs
 
 # 1.12.2

--- a/pdaltools/_version.py
+++ b/pdaltools/_version.py
@@ -1,4 +1,4 @@
-__version__ = "1.12.2"
+__version__ = "1.12.3"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- [fix] add_points_in_pointcloud: format consistency when input shapefile does not have a crs