### PR TITLE
update standardize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # dev
 - [fix] update pandas to 3.0.0
+- [update] standarize accept pdal filter as an input data
 
 # 1.15.9
 - [fix] color: fix main

--- a/pdaltools/standardize_format.py
+++ b/pdaltools/standardize_format.py
@@ -9,9 +9,10 @@
 """
 
 import argparse
+import json
 import os
 import tempfile
-from typing import Dict, List
+from typing import Any, Dict, List, Sequence
 
 import pdal
 
@@ -45,13 +46,6 @@ def parse_args():
     )
     parser.add_argument("--projection", default="EPSG:2154", type=str, help="Projection, eg. EPSG:2154")
     parser.add_argument(
-        "--class_points_removed",
-        default=[],
-        nargs="*",
-        type=str,
-        help="List of classes number. Points of this classes will be removed from the file",
-    )
-    parser.add_argument(
         "--extra_dims",
         default=[],
         nargs="*",
@@ -66,7 +60,35 @@ def parse_args():
         type=str,
         help="Rename dimensions in pairs: --rename_dims old_name1 new_name1 old_name2 new_name2 ...",
     )
+    parser.add_argument(
+        "--extra_filters",
+        default=None,
+        metavar="JSON",
+        help='Optional JSON array of PDAL filter stages (each object must have a "type" key), '
+        "inserted in order after readers.las and before writers.las.",
+    )
     return parser.parse_args()
+
+
+def parse_optional_extra_filters_json(raw: str | None) -> Sequence[Dict[str, Any]] | None:
+    """Parse CLI ``--extra_filters``: a JSON array of PDAL stage dicts, or ``None`` if unset/blank."""
+    if raw is None:
+        return None
+    stripped = raw.strip()
+    if not stripped:
+        return None
+    try:
+        parsed = json.loads(stripped)
+    except json.JSONDecodeError as e:
+        raise ValueError(f"invalid JSON for --extra_filters: {e}") from e
+    if not isinstance(parsed, list):
+        raise ValueError("--extra_filters must be a JSON array of objects")
+    for i, stage in enumerate(parsed):
+        if not isinstance(stage, dict) or "type" not in stage:
+            raise ValueError(
+                f"--extra_filters[{i}] must be an object with a 'type' key (PDAL stage), got {stage!r}."
+            )
+    return parsed
 
 
 def get_writer_parameters(new_parameters: Dict) -> Dict:
@@ -78,59 +100,106 @@ def get_writer_parameters(new_parameters: Dict) -> Dict:
     return params
 
 
+def build_standardize_pipeline_json(
+    input_path: str,
+    output_path: str,
+    writer_parameter_overrides: Dict,
+    extra_filters: Sequence[Dict[str, Any]] | None = None,
+) -> str:
+    """
+    Build a PDAL pipeline as a JSON string:
+
+    ``readers.las`` → optional ``extra_filters`` → ``writers.las`` with :data:`STANDARD_PARAMETERS`
+    merged with ``writer_parameter_overrides``.
+
+    ``extra_filters`` is a sequence of PDAL stage dicts (each must include a ``type`` key), inserted
+    in order before the writer. Do not put a final ``writers.las`` there; the closing writer stage
+    is always appended by this function.
+
+    Example — remove classes 64 and 65 before the writer::
+        standardize(
+            "in.laz",
+            "out.laz",
+            {"dataformat_id": 6, "a_srs": "EPSG:2154", "extra_dims": []},
+            extra_filters=[{"type": "filters.expression", "expression": "Classification != 64&&Classification != 65"}],
+        )
+    """
+    writer_opts = get_writer_parameters(writer_parameter_overrides)
+    stages: List[Dict] = [{"type": "readers.las", "filename": input_path}]
+    if extra_filters:
+        for i, stage in enumerate(extra_filters):
+            if not isinstance(stage, dict) or "type" not in stage:
+                raise ValueError(
+                    f"extra_filters[{i}] must be a dict with a 'type' key (PDAL stage), got {stage!r}."
+                )
+            stages.append(dict(stage))
+    stages.append({"type": "writers.las", "filename": output_path, "forward": "all", **writer_opts})
+    return json.dumps(stages)
+
+
 @copy_and_hack_decorator
 def standardize(
-    input_file: str, 
-    output_file: str, 
-    params_from_parser: Dict, 
-    classes_to_remove: List = [], 
-    rename_dims: List = []
+    input_file: str,
+    output_file: str,
+    writer_parameter_overrides: Dict,
+    rename_dims: List | None = None,
+    extra_filters: Sequence[Dict[str, Any]] | None = None,
 ) -> None:
     """
-    Standardize a LAS/LAZ file with improved error handling and resource management.
-    
-    Args:
-        input_file: Input file path
-        output_file: Output file path
-        params_from_parser: Parameters for the PDAL writer
-        classes_to_remove: List of classification classes to remove
-        rename_dims: List of dimension names to rename (pairs of old_name, new_name)
-    """
-    params = get_writer_parameters(params_from_parser)
-    tmp_file_name = None
+    Build the standardization pipeline via :func:`build_standardize_pipeline_json` and run it.
 
+    ``input_file`` must remain the first argument for :func:`pdaltools.unlock_file.copy_and_hack_decorator`.
+
+    Args:
+        input_file: Input LAS/LAZ path.
+        output_file: Output LAS/LAZ path.
+        writer_parameter_overrides: Writer options merged with :data:`STANDARD_PARAMETERS` (e.g. ``dataformat_id``, ``a_srs``, ``extra_dims``).
+        rename_dims: Optional flat list ``[old0, new0, ...]``; a temp copy is renamed before PDAL reads it.
+        extra_filters: Optional PDAL stages before the writer (see :func:`build_standardize_pipeline_json`).
+    """
+    rename_dims = rename_dims or []
+    tmp_file_name = None
     try:
-        # Create temporary file for dimension renaming if needed
         if rename_dims:
             with tempfile.NamedTemporaryFile(suffix=".laz", delete=False) as tmp_file:
                 tmp_file_name = tmp_file.name
-                old_dims = rename_dims[::2]
-                new_dims = rename_dims[1::2]
-                rename_dimension(input_file, tmp_file_name, old_dims, new_dims)
-                input_file = tmp_file_name
+            old_dims = rename_dims[::2]
+            new_dims = rename_dims[1::2]
+            rename_dimension(input_file, tmp_file_name, old_dims, new_dims)
+            reader_path = tmp_file_name
+        else:
+            reader_path = input_file
 
-        pipeline = pdal.Pipeline()
-        pipeline |= pdal.Reader.las(input_file)
-        if classes_to_remove:
-            expression = "&&".join([f"Classification != {c}" for c in classes_to_remove])
-            pipeline |= pdal.Filter.expression(expression=expression)
-        pipeline |= pdal.Writer(filename=output_file, forward="all", **params)
-        pipeline.execute()
-
+        pipeline_json = build_standardize_pipeline_json(
+            reader_path,
+            output_file,
+            writer_parameter_overrides,
+            extra_filters=extra_filters,
+        )
+        pdal.Pipeline(pipeline_json).execute()
     finally:
-        # Clean up temporary file
         if tmp_file_name and os.path.exists(tmp_file_name):
             os.remove(tmp_file_name)
 
 
 def main():
     args = parse_args()
+    try:
+        extra_filters = parse_optional_extra_filters_json(args.extra_filters)
+    except ValueError as e:
+        raise SystemExit(f"standardize_format: {e}") from e
     params_from_parser = dict(
         dataformat_id=args.record_format,
         a_srs=args.projection,
         extra_dims=args.extra_dims,
     )
-    standardize(args.input_file, args.output_file, params_from_parser, args.class_points_removed, args.rename_dims)
+    standardize(
+        args.input_file,
+        args.output_file,
+        params_from_parser,
+        args.rename_dims,
+        extra_filters,
+    )
 
 
 if __name__ == "__main__":

--- a/pdaltools/standardize_format.py
+++ b/pdaltools/standardize_format.py
@@ -42,16 +42,12 @@ def parse_args():
     parser.add_argument("--input_file", type=str, help="Laz input file.")
     parser.add_argument("--output_file", type=str, help="Laz output file")
     parser.add_argument(
-        "--record_format", choices=[6, 8], type=int, help="Record format: 6 (no color) or 8 (4 color channels)"
-    )
-    parser.add_argument("--projection", default="EPSG:2154", type=str, help="Projection, eg. EPSG:2154")
-    parser.add_argument(
-        "--extra_dims",
-        default=[],
-        nargs="*",
-        type=str,
-        help="List of extra dims to keep in the output (default=[], use 'all' to keep all extra dims), "
-        "extra_dims must be specified with their type (see pdal.writers.las documentation, eg 'dim1=double')",
+        "--writer_parameters",
+        default=None,
+        metavar="JSON",
+        help="JSON object of writers.las overrides merged with built-in defaults (e.g. "
+        '{"dataformat_id": 6, "a_srs": "EPSG:2154", "extra_dims": []} or "extra_dims": ["all"]). '
+        "Omit or pass '{}' to use only defaults.",
     )
     parser.add_argument(
         "--rename_dims",
@@ -70,17 +66,38 @@ def parse_args():
     return parser.parse_args()
 
 
-def parse_optional_extra_filters_json(raw: str | None) -> Sequence[Dict[str, Any]] | None:
-    """Parse CLI ``--extra_filters``: a JSON array of PDAL stage dicts, or ``None`` if unset/blank."""
+def _parse_cli_json_if_nonblank(raw: str | None, flag: str) -> Any | None:
+    """If ``raw`` is unset or whitespace-only, return ``None``; otherwise return ``json.loads`` result.
+
+    Raises:
+        ValueError: invalid JSON (message includes ``flag``).
+    """
     if raw is None:
         return None
     stripped = raw.strip()
     if not stripped:
         return None
     try:
-        parsed = json.loads(stripped)
+        return json.loads(stripped)
     except json.JSONDecodeError as e:
-        raise ValueError(f"invalid JSON for --extra_filters: {e}") from e
+        raise ValueError(f"invalid JSON for {flag}: {e}") from e
+
+
+def parse_writer_parameters_json(raw: str | None) -> Dict[str, Any]:
+    """Parse CLI ``--writer_parameters``: JSON object merged over :data:`STANDARD_PARAMETERS`; omit or blank for ``{}``."""
+    parsed = _parse_cli_json_if_nonblank(raw, "--writer_parameters")
+    if parsed is None:
+        return {}
+    if not isinstance(parsed, dict):
+        raise ValueError("--writer_parameters must be a JSON object")
+    return parsed
+
+
+def parse_optional_extra_filters_json(raw: str | None) -> Sequence[Dict[str, Any]] | None:
+    """Parse CLI ``--extra_filters``: a JSON array of PDAL stage dicts, or ``None`` if unset/blank."""
+    parsed = _parse_cli_json_if_nonblank(raw, "--extra_filters")
+    if parsed is None:
+        return None
     if not isinstance(parsed, list):
         raise ValueError("--extra_filters must be a JSON array of objects")
     for i, stage in enumerate(parsed):
@@ -103,7 +120,8 @@ def get_writer_parameters(new_parameters: Dict) -> Dict:
 def build_standardize_pipeline_json(
     input_path: str,
     output_path: str,
-    writer_parameter_overrides: Dict,
+    *,
+    writer_parameters: Dict,
     extra_filters: Sequence[Dict[str, Any]] | None = None,
 ) -> str:
     """
@@ -124,7 +142,7 @@ def build_standardize_pipeline_json(
             extra_filters=[{"type": "filters.expression", "expression": "Classification != 64&&Classification != 65"}],
         )
     """
-    writer_opts = get_writer_parameters(writer_parameter_overrides)
+    writer_parameters = get_writer_parameters(writer_parameters)
     stages: List[Dict] = [{"type": "readers.las", "filename": input_path}]
     if extra_filters:
         for i, stage in enumerate(extra_filters):
@@ -133,7 +151,7 @@ def build_standardize_pipeline_json(
                     f"extra_filters[{i}] must be a dict with a 'type' key (PDAL stage), got {stage!r}."
                 )
             stages.append(dict(stage))
-    stages.append({"type": "writers.las", "filename": output_path, "forward": "all", **writer_opts})
+    stages.append({"type": "writers.las", "filename": output_path, "forward": "all", **writer_parameters})
     return json.dumps(stages)
 
 
@@ -141,7 +159,8 @@ def build_standardize_pipeline_json(
 def standardize(
     input_file: str,
     output_file: str,
-    writer_parameter_overrides: Dict,
+    *,
+    writer_parameters: Dict,
     rename_dims: List | None = None,
     extra_filters: Sequence[Dict[str, Any]] | None = None,
 ) -> None:
@@ -153,13 +172,17 @@ def standardize(
     Args:
         input_file: Input LAS/LAZ path.
         output_file: Output LAS/LAZ path.
-        writer_parameter_overrides: Writer options merged with :data:`STANDARD_PARAMETERS` (e.g. ``dataformat_id``, ``a_srs``, ``extra_dims``).
+        writer_parameters: Writer options merged with :data:`STANDARD_PARAMETERS` (e.g. ``dataformat_id``, ``a_srs``, ``extra_dims``).
         rename_dims: Optional flat list ``[old0, new0, ...]``; a temp copy is renamed before PDAL reads it.
         extra_filters: Optional PDAL stages before the writer (see :func:`build_standardize_pipeline_json`).
     """
     rename_dims = rename_dims or []
     tmp_file_name = None
     try:
+        
+        # this step is used to rename the dimensions if the user wants to rename the dimensions
+        # it should be process first to avoid issues with the extra_filters
+        # there is no pdal function to do this, so we need to use a temporary file
         if rename_dims:
             with tempfile.NamedTemporaryFile(suffix=".laz", delete=False) as tmp_file:
                 tmp_file_name = tmp_file.name
@@ -170,13 +193,15 @@ def standardize(
         else:
             reader_path = input_file
 
+        # build the pipeline json
         pipeline_json = build_standardize_pipeline_json(
             reader_path,
             output_file,
-            writer_parameter_overrides,
+            writer_parameters=writer_parameters,
             extra_filters=extra_filters,
         )
         pdal.Pipeline(pipeline_json).execute()
+
     finally:
         if tmp_file_name and os.path.exists(tmp_file_name):
             os.remove(tmp_file_name)
@@ -184,21 +209,23 @@ def standardize(
 
 def main():
     args = parse_args()
+    
+    try:
+        writer_params = parse_writer_parameters_json(args.writer_parameters)
+    except ValueError as e:
+        raise SystemExit(f"standardize_format: {e}") from e
+    
     try:
         extra_filters = parse_optional_extra_filters_json(args.extra_filters)
     except ValueError as e:
         raise SystemExit(f"standardize_format: {e}") from e
-    params_from_parser = dict(
-        dataformat_id=args.record_format,
-        a_srs=args.projection,
-        extra_dims=args.extra_dims,
-    )
+    
     standardize(
         args.input_file,
         args.output_file,
-        params_from_parser,
-        args.rename_dims,
-        extra_filters,
+        writer_parameters=writer_params,
+        rename_dims=args.rename_dims,
+        extra_filters=extra_filters,
     )
 
 

--- a/script/test/test_run_remove_classes_in_las.sh
+++ b/script/test/test_run_remove_classes_in_las.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Retrait des points de classification 2 via --extra_filters (JSON).
+# Drop LAS classification 2 using --extra_filters (JSON).
 set -euo pipefail
 cd "$(dirname "$0")/../.."
 mkdir -p test/tmp

--- a/script/test/test_run_remove_classes_in_las.sh
+++ b/script/test/test_run_remove_classes_in_las.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Drop LAS classification 2 using --extra_filters (JSON).
+# Drop LAS classification 2 using --extra_filters (JSON) and --writer_parameters (JSON).
 set -euo pipefail
 cd "$(dirname "$0")/../.."
 mkdir -p test/tmp
@@ -7,8 +7,6 @@ mkdir -p test/tmp
 python -m pdaltools.standardize_format \
     --input_file test/data/classified_laz/test_data_77050_627755_LA93_IGN69.laz \
     --output_file test/tmp/replaced_cmdline.laz \
-    --record_format 6 \
-    --projection EPSG:2154 \
-    --extra_dims \
+    --writer_parameters '{"dataformat_id":6,"a_srs":"EPSG:2154","extra_dims":[]}' \
     --rename_dims \
     --extra_filters '[{"type":"filters.expression","expression":"Classification != 2"}]'

--- a/script/test/test_run_remove_classes_in_las.sh
+++ b/script/test/test_run_remove_classes_in_las.sh
@@ -1,5 +1,14 @@
+#!/usr/bin/env bash
+# Retrait des points de classification 2 via --extra_filters (JSON).
+set -euo pipefail
+cd "$(dirname "$0")/../.."
+mkdir -p test/tmp
+
 python -m pdaltools.standardize_format \
     --input_file test/data/classified_laz/test_data_77050_627755_LA93_IGN69.laz \
     --output_file test/tmp/replaced_cmdline.laz \
     --record_format 6 \
-    --class_points_removed 2 \
+    --projection EPSG:2154 \
+    --extra_dims \
+    --rename_dims \
+    --extra_filters '[{"type":"filters.expression","expression":"Classification != 2"}]'

--- a/test/test_standardize_format.py
+++ b/test/test_standardize_format.py
@@ -18,9 +18,11 @@ from pdaltools.count_occurences.count_occurences_for_attribute import (
 )
 from pdaltools.las_comparison import compare_las_dimensions
 from pdaltools.standardize_format import (
+    _parse_cli_json_if_nonblank,
     build_standardize_pipeline_json,
     main,
     parse_optional_extra_filters_json,
+    parse_writer_parameters_json,
     standardize,
 )
 
@@ -60,9 +62,9 @@ def _standardize(
     standardize(
         input_file,
         output_file,
-        writer_overrides,
-        rename_dims,
-        extra_filters,
+        writer_parameters=writer_overrides,
+        rename_dims=rename_dims,
+        extra_filters=extra_filters,
     )
 
 
@@ -71,7 +73,7 @@ def test_build_standardize_pipeline_json_extra_filters_order():
         build_standardize_pipeline_json(
             "in.laz",
             "out.laz",
-            {"dataformat_id": 6, "a_srs": "EPSG:2154", "extra_dims": []},
+            writer_parameters={"dataformat_id": 6, "a_srs": "EPSG:2154", "extra_dims": []},
             extra_filters=[
                 *_extra_filters_drop_classifications(["2"]),
                 {"type": "filters.assign", "value": "Classification = 2 WHERE Classification==5"},
@@ -94,7 +96,7 @@ def test_build_standardize_pipeline_json_several_extra_filters_order():
         build_standardize_pipeline_json(
             "a.laz",
             "b.laz",
-            DEFAULT_PARAMS,
+            writer_parameters=DEFAULT_PARAMS,
             extra_filters=[
                 {"type": "filters.expression", "expression": "Classification != 9"},
                 {"type": "filters.range", "limits": "Classification[0:255]"},
@@ -438,12 +440,8 @@ def test_main_with_rename_dimensions():
             input_file,
             "--output_file",
             output_file,
-            "--record_format",
-            "6",
-            "--projection",
-            "EPSG:2154",
-            "--extra_dims",
-            "all",
+            "--writer_parameters",
+            '{"dataformat_id": 6, "a_srs": "EPSG:2154", "extra_dims": ["all"]}',
             "--rename_dims",
             "dtm_marker",
             "new_dtm_marker",
@@ -468,6 +466,28 @@ def test_main_with_rename_dimensions():
     finally:
         # Restore original sys.argv
         sys.argv = original_argv
+
+
+def test_parse_cli_json_if_nonblank():
+    assert _parse_cli_json_if_nonblank(None, "--flag") is None
+    assert _parse_cli_json_if_nonblank("", "--flag") is None
+    assert _parse_cli_json_if_nonblank("   ", "--flag") is None
+    assert _parse_cli_json_if_nonblank("42", "--flag") == 42
+    assert _parse_cli_json_if_nonblank("[1]", "--flag") == [1]
+    with pytest.raises(ValueError, match="invalid JSON for --myflag"):
+        _parse_cli_json_if_nonblank("{", "--myflag")
+
+
+def test_parse_writer_parameters_json():
+    assert parse_writer_parameters_json(None) == {}
+    assert parse_writer_parameters_json("") == {}
+    assert parse_writer_parameters_json("  \n") == {}
+    assert parse_writer_parameters_json("{}") == {}
+    assert parse_writer_parameters_json('{"dataformat_id": 8}') == {"dataformat_id": 8}
+    with pytest.raises(ValueError, match="JSON"):
+        parse_writer_parameters_json("{not json")
+    with pytest.raises(ValueError, match="object"):
+        parse_writer_parameters_json("[]")
 
 
 def test_parse_optional_extra_filters_json():
@@ -498,10 +518,8 @@ def test_main_with_extra_filters_reduces_point_count():
             input_file,
             "--output_file",
             output_file,
-            "--record_format",
-            "6",
-            "--projection",
-            "EPSG:2154",
+            "--writer_parameters",
+            '{"dataformat_id": 6, "a_srs": "EPSG:2154", "extra_dims": []}',
             "--extra_filters",
             extra_filters_json,
         ]
@@ -512,6 +530,34 @@ def test_main_with_extra_filters_reduces_point_count():
     original_count = compute_count_one_file(input_file)
     new_count = compute_count_one_file(output_file)
     assert new_count < original_count, "Points count should be reduced after removing class 64"
+
+
+def test_main_without_writer_parameters_uses_standard_defaults():
+    """Omitting ``--writer_parameters`` is equivalent to passing ``{}`` (built-in writer defaults only)."""
+    input_file = os.path.join(INPUT_DIR, "test_data_77055_627755_LA93_IGN69_extra_dims.laz")
+    output_file = os.path.join(TMP_PATH, "test_main_no_writer_params.laz")
+    original_argv = sys.argv
+    try:
+        sys.argv = [
+            "standardize_format",
+            "--input_file",
+            input_file,
+            "--output_file",
+            output_file,
+        ]
+        main()
+    finally:
+        sys.argv = original_argv
+    assert os.path.isfile(output_file)
+    json_info = get_pdal_infos_summary(output_file)
+    pdal_ver = Version(str(pdal.info.version))
+    if pdal_ver < Version("2.5"):
+        raise NotImplementedError("This test is not implemented for pdal < 2.5")
+    elif pdal_ver <= Version("2.5.2"):
+        metadata = json_info["summary"]["metadata"][1]
+    else:
+        metadata = json_info["summary"]["metadata"]
+    assert metadata["dataformat_id"] == 6
 
 
 def test_standardize_drop_class_64_via_extra_filters():

--- a/test/test_standardize_format.py
+++ b/test/test_standardize_format.py
@@ -1,5 +1,7 @@
+import json
 import logging
 import os
+from typing import Any, Dict, List, Sequence
 import platform
 import shutil
 import subprocess as sp
@@ -15,7 +17,12 @@ from pdaltools.count_occurences.count_occurences_for_attribute import (
     compute_count_one_file,
 )
 from pdaltools.las_comparison import compare_las_dimensions
-from pdaltools.standardize_format import main, standardize
+from pdaltools.standardize_format import (
+    build_standardize_pipeline_json,
+    main,
+    parse_optional_extra_filters_json,
+    standardize,
+)
 
 TEST_PATH = os.path.dirname(os.path.abspath(__file__))
 TMP_PATH = os.path.join(TEST_PATH, "tmp")
@@ -23,6 +30,128 @@ INPUT_DIR = os.path.join(TEST_PATH, "data")
 
 DEFAULT_PARAMS = {"dataformat_id": 6, "a_srs": "EPSG:2154", "extra_dims": []}
 DEFAULT_PARAMS_WITH_ALL_EXTRA_DIMS = {"dataformat_id": 6, "a_srs": "EPSG:2154", "extra_dims": "all"}
+
+
+def _extra_filters_drop_classifications(class_values: Sequence) -> List[Dict[str, Any]]:
+    """Test helper: build ``filters.expression`` stages to drop LAS classifications (``&&`` of ``Classification != …``).
+        This permit to remove points by classification before the writer.
+    """
+    if not class_values:
+        return []
+    expression = "&&".join(f"Classification != {c}" for c in class_values)
+    return [{"type": "filters.expression", "expression": expression}]
+
+
+def test_helper_extra_filters_drop_classifications_expression():
+    assert _extra_filters_drop_classifications([]) == []
+    assert _extra_filters_drop_classifications([64, 65]) == [
+        {"type": "filters.expression", "expression": "Classification != 64&&Classification != 65"}
+    ]
+
+
+def _standardize(
+    input_file: str,
+    output_file: str,
+    writer_overrides: dict,
+    rename_dims: list | None = None,
+    extra_filters: list | None = None,
+) -> None:
+    standardize(
+        input_file,
+        output_file,
+        writer_overrides,
+        rename_dims,
+        extra_filters,
+    )
+
+
+def test_build_standardize_pipeline_json_extra_filters_order():
+    stages = json.loads(
+        build_standardize_pipeline_json(
+            "in.laz",
+            "out.laz",
+            {"dataformat_id": 6, "a_srs": "EPSG:2154", "extra_dims": []},
+            extra_filters=[
+                *_extra_filters_drop_classifications(["2"]),
+                {"type": "filters.assign", "value": "Classification = 2 WHERE Classification==5"},
+            ],
+        )
+    )
+    assert [s["type"] for s in stages] == [
+        "readers.las",
+        "filters.expression",
+        "filters.assign",
+        "writers.las",
+    ]
+    assert stages[1]["expression"] == "Classification != 2"
+    assert stages[2]["value"] == "Classification = 2 WHERE Classification==5"
+
+
+def test_build_standardize_pipeline_json_several_extra_filters_order():
+    """Plusieurs étapes ``extra_filters`` (types PDAL différents) dans l’ordre entre reader et writer."""
+    stages = json.loads(
+        build_standardize_pipeline_json(
+            "a.laz",
+            "b.laz",
+            DEFAULT_PARAMS,
+            extra_filters=[
+                {"type": "filters.expression", "expression": "Classification != 9"},
+                {"type": "filters.range", "limits": "Classification[0:255]"},
+                {"type": "filters.assign", "value": "Intensity = Intensity WHERE Intensity >= 0"},
+            ],
+        )
+    )
+    assert [s["type"] for s in stages] == [
+        "readers.las",
+        "filters.expression",
+        "filters.range",
+        "filters.assign",
+        "writers.las",
+    ]
+    assert stages[1]["expression"] == "Classification != 9"
+    assert stages[2]["limits"] == "Classification[0:255]"
+    assert stages[3]["value"] == "Intensity = Intensity WHERE Intensity >= 0"
+
+
+def test_standardize_several_extra_filters_point_count_unchanged():
+    """Chaîne ``expression`` + ``range`` + ``assign`` : même nombre de points."""
+    input_file = os.path.join(INPUT_DIR, "test_data_77055_627755_LA93_IGN69_extra_dims.laz")
+    output_file = os.path.join(TMP_PATH, "formatted_several_extra_filters.laz")
+    extra_filters = [
+        {"type": "filters.expression", "expression": "Z >= -1e38"},
+        {"type": "filters.range", "limits": "Classification[0:255]"},
+        {"type": "filters.assign", "value": "Intensity = Intensity WHERE Intensity >= 0"},
+    ]
+    _standardize(input_file, output_file, DEFAULT_PARAMS, extra_filters=extra_filters)
+    assert os.path.isfile(output_file)
+    assert len(laspy.read(input_file)) == len(laspy.read(output_file))
+
+
+def test_standardize_with_extra_filters_assign():
+    """End-to-end standardize with ``filters.assign`` in ``extra_filters`` (no-op on ReturnNumber)."""
+    input_file = os.path.join(INPUT_DIR, "test_data_77055_627755_LA93_IGN69_extra_dims.laz")
+    output_file = os.path.join(TMP_PATH, "formatted_with_filters_assign.laz")
+    extra_filters = [
+        {"type": "filters.assign", "value": "Classification = 2 WHERE Classification==5"},
+    ]
+    _standardize(input_file, output_file, DEFAULT_PARAMS, extra_filters=extra_filters)
+    assert os.path.isfile(output_file)
+    assert len(laspy.read(input_file)) == len(laspy.read(output_file))
+
+    # Check that there is no point with classification 5
+    with laspy.open(output_file) as las_file:
+        las = las_file.read()
+        assert not any(las.classification == 5)
+    # Check that point of classification 2 of output are the same as input file + points from Classification 5
+    with laspy.open(input_file) as las_file:
+        input_las = las_file.read()
+        input_points_classification_5 = input_las[input_las.classification == 5]
+    with laspy.open(output_file) as las_file:
+        output_las = las_file.read()
+        output_points_classification_2 = output_las[output_las.classification == 2]    
+    assert len(output_points_classification_2) == len(input_points_classification_5) + len(input_las[input_las.classification == 2])
+
+
 
 MUTLIPLE_PARAMS = [
     DEFAULT_PARAMS,
@@ -53,7 +182,7 @@ def setup_module(module):
 def test_standardize_format(params):
     input_file = os.path.join(INPUT_DIR, "test_data_77055_627755_LA93_IGN69_extra_dims.laz")
     output_file = os.path.join(TMP_PATH, "formatted.laz")
-    standardize(input_file, output_file, params, [])
+    _standardize(input_file, output_file, params)
     # check file exists
     assert os.path.isfile(output_file)
     # check values from metadata
@@ -112,7 +241,7 @@ def test_standardize_rename_dimensions(params, rename_dims):
         original_dims = las.point_format.dimension_names
 
     # Standardize with dimension renaming
-    standardize(input_file, output_file, params, [], rename_dims)
+    _standardize(input_file, output_file, params, rename_dims=rename_dims)
 
     # Verify dimensions were renamed
     with laspy.open(output_file) as las_file:
@@ -159,7 +288,8 @@ def test_standardize_rename_dimensions(params, rename_dims):
 def test_standardize_classes(classes_to_remove):
     input_file = os.path.join(INPUT_DIR, "test_data_77055_627755_LA93_IGN69_extra_dims.laz")
     output_file = os.path.join(TMP_PATH, "formatted.laz")
-    standardize(input_file, output_file, DEFAULT_PARAMS, classes_to_remove)
+    extra = _extra_filters_drop_classifications(classes_to_remove) or None
+    _standardize(input_file, output_file, DEFAULT_PARAMS, extra_filters=extra)
     # Check that there is the expected number of points for each class
     expected_points_counts = compute_count_one_file(input_file)
     for cl in classes_to_remove:
@@ -205,7 +335,13 @@ def test_standardize_with_all_options():
 
     # Standardize with all extra dimensions
     params = DEFAULT_PARAMS_WITH_ALL_EXTRA_DIMS
-    standardize(input_file, output_file, params, remove_classes, rename_dims)
+    _standardize(
+        input_file,
+        output_file,
+        params,
+        rename_dims=rename_dims,
+        extra_filters=_extra_filters_drop_classifications(remove_classes),
+    )
 
     # Check that there is the expected number of points for each class
     expected_points_counts = compute_count_one_file(input_file)
@@ -248,14 +384,14 @@ def test_standardize_does_NOT_produce_any_warning_with_Lasinfo():
     # if you want to see input_file warnings
     # assert_lasinfo_no_warning(input_file)
 
-    standardize(input_file, output_file, DEFAULT_PARAMS, [], [])
+    _standardize(input_file, output_file, DEFAULT_PARAMS)
     assert_lasinfo_no_warning(output_file)
 
 
 def test_standardize_malformed_laz():
     input_file = os.path.join(TEST_PATH, "data/test_pdalfail_0643_6319_LA93_IGN69.laz")
     output_file = os.path.join(TMP_PATH, "standardize_pdalfail_0643_6319_LA93_IGN69.laz")
-    standardize(input_file, output_file, DEFAULT_PARAMS, [], [])
+    _standardize(input_file, output_file, DEFAULT_PARAMS)
     assert os.path.isfile(output_file)
 
 
@@ -266,7 +402,7 @@ def test_standardize_with_extra_dims_origin_and_dxm_marker():
     input_file = os.path.join(INPUT_DIR, "las_with_origin_dsmMarker.laz")
     output_file = os.path.join(TMP_PATH, "test_main_with_extra_dims.laz")
 
-    standardize(input_file, output_file, DEFAULT_PARAMS_WITH_ALL_EXTRA_DIMS, [], [])
+    _standardize(input_file, output_file, DEFAULT_PARAMS_WITH_ALL_EXTRA_DIMS)
 
     # Check that the output file exists
     assert os.path.isfile(output_file)
@@ -333,18 +469,28 @@ def test_main_with_rename_dimensions():
         sys.argv = original_argv
 
 
-def test_main_with_class_points_removed():
-    """
-    Test the main function with class points removed
-    """
+def test_parse_optional_extra_filters_json():
+    assert parse_optional_extra_filters_json(None) is None
+    assert parse_optional_extra_filters_json("") is None
+    assert parse_optional_extra_filters_json("  \n") is None
+    assert parse_optional_extra_filters_json(
+        '[{"type": "filters.expression", "expression": "Z>0"}]'
+    ) == [{"type": "filters.expression", "expression": "Z>0"}]
+    with pytest.raises(ValueError, match="JSON"):
+        parse_optional_extra_filters_json("{not json")
+    with pytest.raises(ValueError, match="array"):
+        parse_optional_extra_filters_json('{"type":"filters.expression"}')
+    with pytest.raises(ValueError, match="type"):
+        parse_optional_extra_filters_json('[{"nope": 1}]')
+
+
+def test_main_with_extra_filters_reduces_point_count():
+    """CLI ``--extra_filters`` : même effet qu’un ``extra_filters`` passé à l’API."""
     input_file = os.path.join(INPUT_DIR, "test_data_77055_627755_LA93_IGN69_extra_dims.laz")
-    output_file = os.path.join(TMP_PATH, "test_main_with_class_remove.laz")
-
-    # Save original sys.argv
+    output_file = os.path.join(TMP_PATH, "test_main_extra_filters.laz")
     original_argv = sys.argv
-
+    extra_filters_json = '[{"type":"filters.expression","expression":"Classification != 64"}]'
     try:
-        # Set up mock command-line arguments
         sys.argv = [
             "standardize_format",
             "--input_file",
@@ -355,24 +501,32 @@ def test_main_with_class_points_removed():
             "6",
             "--projection",
             "EPSG:2154",
-            "--class_points_removed",
-            "64",
+            "--extra_filters",
+            extra_filters_json,
         ]
-
-        # Run main function
         main()
-
-        # Verify output file exists
-        assert os.path.isfile(output_file)
-
-        # Verify points count is reduced
-        original_count = compute_count_one_file(input_file)
-        new_count = compute_count_one_file(output_file)
-        assert new_count < original_count, "Points count should be reduced after removing class 64"
-
     finally:
-        # Restore original sys.argv
         sys.argv = original_argv
+    assert os.path.isfile(output_file)
+    original_count = compute_count_one_file(input_file)
+    new_count = compute_count_one_file(output_file)
+    assert new_count < original_count, "Points count should be reduced after removing class 64"
+
+
+def test_standardize_drop_class_64_via_extra_filters():
+    """Retrait de points par classe via ``extra_filters`` (API Python, pas le CLI ``main``)."""
+    input_file = os.path.join(INPUT_DIR, "test_data_77055_627755_LA93_IGN69_extra_dims.laz")
+    output_file = os.path.join(TMP_PATH, "test_drop_class_64_extra_filters.laz")
+    _standardize(
+        input_file,
+        output_file,
+        DEFAULT_PARAMS,
+        extra_filters=_extra_filters_drop_classifications(["64"]),
+    )
+    assert os.path.isfile(output_file)
+    original_count = compute_count_one_file(input_file)
+    new_count = compute_count_one_file(output_file)
+    assert new_count < original_count, "Points count should be reduced after removing class 64"
 
 
 if __name__ == "__main__":

--- a/test/test_standardize_format.py
+++ b/test/test_standardize_format.py
@@ -34,7 +34,8 @@ DEFAULT_PARAMS_WITH_ALL_EXTRA_DIMS = {"dataformat_id": 6, "a_srs": "EPSG:2154", 
 
 def _extra_filters_drop_classifications(class_values: Sequence) -> List[Dict[str, Any]]:
     """Test helper: build ``filters.expression`` stages to drop LAS classifications (``&&`` of ``Classification != …``).
-        This permit to remove points by classification before the writer.
+
+    Allows removing points by classification before the writer.
     """
     if not class_values:
         return []
@@ -88,7 +89,7 @@ def test_build_standardize_pipeline_json_extra_filters_order():
 
 
 def test_build_standardize_pipeline_json_several_extra_filters_order():
-    """Plusieurs étapes ``extra_filters`` (types PDAL différents) dans l’ordre entre reader et writer."""
+    """Several ``extra_filters`` stages (different PDAL types) in order between reader and writer."""
     stages = json.loads(
         build_standardize_pipeline_json(
             "a.laz",
@@ -114,7 +115,7 @@ def test_build_standardize_pipeline_json_several_extra_filters_order():
 
 
 def test_standardize_several_extra_filters_point_count_unchanged():
-    """Chaîne ``expression`` + ``range`` + ``assign`` : même nombre de points."""
+    """``expression`` + ``range`` + ``assign`` chain: input and output point counts match."""
     input_file = os.path.join(INPUT_DIR, "test_data_77055_627755_LA93_IGN69_extra_dims.laz")
     output_file = os.path.join(TMP_PATH, "formatted_several_extra_filters.laz")
     extra_filters = [
@@ -485,7 +486,7 @@ def test_parse_optional_extra_filters_json():
 
 
 def test_main_with_extra_filters_reduces_point_count():
-    """CLI ``--extra_filters`` : même effet qu’un ``extra_filters`` passé à l’API."""
+    """CLI ``--extra_filters`` matches passing ``extra_filters`` to the Python API."""
     input_file = os.path.join(INPUT_DIR, "test_data_77055_627755_LA93_IGN69_extra_dims.laz")
     output_file = os.path.join(TMP_PATH, "test_main_extra_filters.laz")
     original_argv = sys.argv
@@ -514,7 +515,7 @@ def test_main_with_extra_filters_reduces_point_count():
 
 
 def test_standardize_drop_class_64_via_extra_filters():
-    """Retrait de points par classe via ``extra_filters`` (API Python, pas le CLI ``main``)."""
+    """Drop points by class via ``extra_filters`` on the Python API (not CLI ``main``)."""
     input_file = os.path.join(INPUT_DIR, "test_data_77055_627755_LA93_IGN69_extra_dims.laz")
     output_file = os.path.join(TMP_PATH, "test_drop_class_64_extra_filters.laz")
     _standardize(


### PR DESCRIPTION
L'idée de cette refactorisation, c'est de pouvoir ajouter des expressions de type filtre panda, donc de pouvoir laisser à l'utilisateur maitre de ce qu'il veut faire. Cela servira à la suppression des classes, au renomage de classes, à l'ajout de dimension, ...  

De même, on généralise les options d'export du LAS via un bout de JSON pdal. Cela laisse à l'utilisateur le soin de créer ses options. 

Cela devrait limiter la reprise de code du standardize